### PR TITLE
chore: add permission test commit marker

### DIFF
--- a/PERMISSION_TEST_COMMIT.txt
+++ b/PERMISSION_TEST_COMMIT.txt
@@ -1,0 +1,1 @@
+Test commit from Codex agent to verify branch push permissions for PR #798.


### PR DESCRIPTION
### Motivation
- Verify whether the current environment can push a tiny change to PR #798 by making a minimal test change on the active branch `work`.

### Description
- Add `PERMISSION_TEST_COMMIT.txt` containing a one-line marker and record the change on branch `work`; a PR record was created via the `make_pr` helper but an actual remote push could not be completed because no remote is configured in this environment.

### Testing
- Repository status and local add/commit operations were executed successfully, and the push attempt failed due to the absence of a configured remote.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e7b791038832f8168efbf0a97da12)