### PR TITLE
Add AGENTS.md and align contributing/changelog guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,8 @@ When creating an issue or pull request:
 - Prefer editing source inputs over generated outputs unless the task explicitly asks for generated artifacts.
 - Do not add new dependencies unless they are necessary and justified in the PR description.
 - Avoid unrelated refactors in the same PR.
+
+## Changelog, documentation, and provenance
+- If behavior, workflow, policy, or contributor expectations change, update `CHANGELOG.md` in **[Unreleased]**.
+- Update supporting documentation (for example `README.md`, `CONTRIBUTING.md`, or `docs/`) when contributor behavior or project workflows are affected.
+- For data/model edits, preserve and/or update provenance-related metadata and explain provenance impacts in the PR description.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - yyyy-mm-dd
  
 ### Added
+- Added and expanded `AGENTS.md` guidance for branch naming, issue/PR label usage, PR hygiene, validation expectations, repo guardrails, and changelog/documentation/provenance expectations.
 
 ### Changed
+- Updated `docs/CONTRIBUTING_SHORT.md` to align branch prefix guidance and add an explicit Unreleased changelog checklist item for workflow/policy/behavior changes.
 
 ### Fixed
 

--- a/docs/CONTRIBUTING_SHORT.md
+++ b/docs/CONTRIBUTING_SHORT.md
@@ -5,7 +5,7 @@ Before you open a pull request (PR), please review this quick checklist.
 For the full contributor guide, see [CONTRIBUTING.md](../CONTRIBUTING.md).
 
 ## Branch & Workflow
-- **Branch name:** use `feature/<topic>`, `issue/<topic>`, or `fix/<topic>`.
+- **Branch name:** use `feature/<topic>`, `issues/<topic>`, `fix/<topic>`, `chore/<topic>`, `hotfix/<topic>`, or `release/<topic>` (as context dictates).
 - **Base branch:** always `main`.
 - Keep branches focused; avoid mixing unrelated changes.
 - PRs should not be bloated, too many changes at one time require extra review.
@@ -50,6 +50,7 @@ Each field must include correct `$meta` provenance tracking where applicable:
 > The `npm run canonicalize` will auto fill this info for you as a "manual" edit. 
 
 ## Pull Request Checklist
+- [ ] Update `CHANGELOG.md` under **[Unreleased]** when behavior, workflow, or policy changes.
 - [ ] Clear, descriptive title.
 - [ ] Summary of what changed and why.
 - [ ] References the relevant workflow(s) or scripts.


### PR DESCRIPTION
## What changed
- Added root `AGENTS.md` guidance for branch naming, issue/PR labels, PR hygiene, validation expectations, guardrails, and changelog/documentation/provenance practices.
- Updated `docs/CONTRIBUTING_SHORT.md` to align branch-prefix conventions and include a checklist item for updating `CHANGELOG.md` Unreleased on behavior/workflow/policy changes.
- Updated `CHANGELOG.md` Unreleased entries to document these policy/documentation updates.

## Why
To centralize contributor/agent expectations and keep process documentation consistent and provenance-aware.

## Validation
- Documentation-only checks via `git status`, `git diff`, and file review (`nl -ba ...`) were completed.

## Labels requested
- `documentation`
- `codex`