### PR TITLE
ci: queue main builds and gate MSI behind site build

### DIFF
--- a/.github/workflows/build-master-suite-index.yml
+++ b/.github/workflows/build-master-suite-index.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
   pull-requests: write
   issues: write
@@ -28,6 +29,57 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Wait for main site build on merge commit
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const mergeSha = context.payload.pull_request?.merge_commit_sha;
+            if (!mergeSha) {
+              core.setFailed('No merge_commit_sha found on pull_request.closed event.');
+              return;
+            }
+
+            const workflow_id = 'build-msr-site.yml';
+            const timeoutMs = 60 * 60 * 1000; // 60 min
+            const pollMs = 20 * 1000; // 20 sec
+            const started = Date.now();
+
+            core.info(`Waiting for ${workflow_id} on merge SHA ${mergeSha}`);
+
+            while (Date.now() - started < timeoutMs) {
+              const resp = await github.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id,
+                head_sha: mergeSha,
+                event: 'push',
+                per_page: 10
+              });
+
+              const run = (resp.data.workflow_runs || []).find(r => r.head_sha === mergeSha);
+              if (run) {
+                core.info(`Found run ${run.id}: status=${run.status}, conclusion=${run.conclusion}`);
+                if (run.status === 'completed') {
+                  if (run.conclusion === 'success') {
+                    core.info('Main site build completed successfully; continuing MSI.');
+                    return;
+                  }
+                  core.setFailed(`Main site build completed with conclusion='${run.conclusion}'. MSI is gated behind a successful site build.`);
+                  return;
+                }
+              } else {
+                core.info('Main site build run not visible yet for this SHA; polling...');
+              }
+
+              await new Promise(resolve => setTimeout(resolve, pollMs));
+            }
+
+            core.setFailed('Timed out waiting for main site build to complete.');
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-msr-site.yml
+++ b/.github/workflows/build-msr-site.yml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
   group: build-main
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:


### PR DESCRIPTION
# Pull Request — MSRBot.io

## Summary
- Set `build-msr-site.yml` concurrency to queue (`cancel-in-progress: false`) so main-site builds no longer cancel each other.
- Added an MSI pre-step in `build-master-suite-index.yml` that waits for the `build-msr-site.yml` run for the merged SHA to complete successfully before continuing.
- Keeps the existing MSI→MRI→URL chain, but starts it only after the main site build finishes.

## Type of Change
- [x] Bug fix
- [x] Workflow / CI update

## Validation
- [x] Workflow logic reviewed for trigger/concurrency interactions
- [x] No app/data payload changes

## Related Issues
References #910
