### PR TITLE
Fix MRI churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - filter comparisons now use normalized URL forms
   - prefix matching now requires explicit intent via trailing `/` in the filter entry.
 - **W3C dated TR stage references not resolving** — expanded W3C URL parsing in `parseRefId` to resolve dated `/TR/YYYY/<STAGE>-<shortname>-<date>` forms beyond REC (for example `WD-CSP3-20160913`, `CR-referrer-policy-20170126`).
+- **MRI add-then-prune churn across extract/build-MRI workflows** — extraction now prunes MRI variants to current `documents.json` reference truth before flush, preventing transient rawVariants (for example self-cites or non-persisted sightings) from being added by extract and then removed by later `buildMasterReferenceIndex` runs.
  
 ## [v1.4.1] - 2026-03-06
  

--- a/src/main/lib/referencing.js
+++ b/src/main/lib/referencing.js
@@ -397,6 +397,12 @@ function mriRecordSighting({ docId, type, refId, cite, href, mapSource, mapDetai
 
   _dirty = true;
 
+  // Keep MRI aligned with documents.json reference semantics:
+  // do not record self-references (e.g., RFC2049 citing "this document").
+  if (refId && docId && String(refId).trim().toUpperCase() === String(docId).trim().toUpperCase()) {
+    return;
+  }
+
   if (refId) {
     const entry = _ensureRef(refId);
     // provenance

--- a/src/main/reports/badRefs.latest.json
+++ b/src/main/reports/badRefs.latest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-10T05:36:35.672Z",
+  "generatedAt": "2026-03-10T16:50:31.042Z",
   "sourcePath": "src/main/data/documents.json",
   "total": 0,
   "badRefs": []

--- a/src/main/reports/masterReferenceIndex.json
+++ b/src/main/reports/masterReferenceIndex.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-03-10T05:36:35.784Z",
+  "generatedAt": "2026-03-10T16:49:38.307Z",
   "stats": {
     "uniqueRefIds": 1508
   },
@@ -191,14 +191,6 @@
         ]
       },
       "rawVariants": [
-        {
-          "docId": "RFC9231",
-          "type": "bibliographic",
-          "cite": "SipHash2",
-          "href": "https://www.aumasson.jp/siphash/siphash.pdf",
-          "rawRef": "Aumasson, J. and D. Bernstein, \"SipHash: A Fast Short-Input PRF\", Department of Computer Science, University of Illinois at Chicago, <https://www.aumasson.jp/siphash/siphash.pdf>.",
-          "title": null
-        },
         {
           "docId": "RFC9231",
           "type": "normative",
@@ -22481,14 +22473,6 @@
           "cite": "RFC 2049",
           "href": "./rfc2049",
           "rawRef": "RFC 2049 ] Borenstein, N., and N. Freed, \"Multipurpose Internet Mail Extensions (MIME) Part Five: Conformance Criteria and Examples\", RFC 2049 , November 1996.",
-          "title": null
-        },
-        {
-          "docId": "RFC2049",
-          "type": "bibliographic",
-          "cite": "RFC2049",
-          "href": "./rfc2049",
-          "rawRef": "RFC-2049 Freed, N. and N. Borenstein, \"Multipurpose Internet Mail Extensions (MIME) Part Five: Conformance Criteria and Examples\", RFC 2049 (this document), Innosoft, First Virtual Holdings, November 1996.",
           "title": null
         }
       ]

--- a/src/main/reports/mri_presence_audit.json
+++ b/src/main/reports/mri_presence_audit.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-10T00:18:27.267Z",
+  "generatedAt": "2026-03-10T16:49:38.337Z",
   "sourcePath": "src/main/data/documents.json",
   "processedDocs": 2301,
   "replayMode": "full-replay",

--- a/src/main/scripts/extractDocs.js
+++ b/src/main/scripts/extractDocs.js
@@ -75,7 +75,7 @@ const badRefsLatestPath = `src/main/reports/badRefs.latest.json`;
 // Raw URL (kept for logging/diagnostics)
 const detailsFileRawUrl = `https://raw.githubusercontent.com/PrZ3r/MSRBot.io/main/${fullDetailsPath}`;
 
-const { parseRefId, extractRefs, mapRefByCite, mriFlush, mriEnsureFile } = require('../lib/referencing');
+const { parseRefId, extractRefs, mapRefByCite, mriFlush, mriEnsureFile, mriPruneToSightings } = require('../lib/referencing');
 
 // Guard to avoid double logging/flushing MRI on multiple exit signals
 let _mriFlushedOnce = false;
@@ -219,6 +219,24 @@ const baseMetaConfig = {
 const metaConfig = mergeMetaConfig(baseMetaConfig, activeProvider.metaConfig || {});
 
 const badRefs = [];
+
+function buildMriSightingIndexFromDocs(docs = []) {
+  const idx = new Set();
+  for (const d of (Array.isArray(docs) ? docs : [])) {
+    const docId = String(d?.docId || '').trim();
+    if (!docId) continue;
+    const refs = d?.references && typeof d.references === 'object' ? d.references : {};
+    for (const [key, type] of [['normative', 'normative'], ['bibliographic', 'bibliographic']]) {
+      const arr = Array.isArray(refs[key]) ? refs[key] : [];
+      for (const refIdRaw of arr) {
+        const refId = String(refIdRaw || '').trim();
+        if (!refId) continue;
+        idx.add(`${refId}||${docId}||${type}`);
+      }
+    }
+  }
+  return idx;
+}
 
 function refsAreDifferent(a, b) {
   const aSorted = [...a].sort();
@@ -928,6 +946,19 @@ for (const doc of results) {
     skippedDocs.forEach(docId => {
       console.log(`- ${docId}`);
     });
+  }
+
+  // Keep MRI variants aligned with current documents truth during extract runs,
+  // so extract-time sightings do not create transient entries later pruned by
+  // buildMasterReferenceIndex.
+  try {
+    const sightIdx = buildMriSightingIndexFromDocs(existingDocs);
+    const pr = mriPruneToSightings(sightIdx, { removeEmptyRefs: true });
+    if ((pr.removedVariants || 0) > 0 || (pr.removedRefs || 0) > 0 || (pr.removedOrphans || 0) > 0) {
+      console.log(`🧹 MRI prune during extract: -${pr.removedVariants || 0} variants, -${pr.removedRefs || 0} refs, -${pr.removedOrphans || 0} orphans`);
+    }
+  } catch (e) {
+    console.warn(`⚠️ MRI prune during extract failed: ${e.message}`);
   }
 
   const formatBadRefText = (raw) => String(raw || '')


### PR DESCRIPTION
FIXED:

- **MRI add-then-prune churn across extract/build-MRI workflows** — extraction now prunes MRI variants to current `documents.json` reference truth before flush, preventing transient rawVariants (for example self-cites or non-persisted sightings) from being added by extract and then removed by later `buildMasterReferenceIndex` runs.