### PR TITLE
chore: add dependabot config for github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with both `npm` and `github-actions` ecosystems
- Consolidates existing npm config (was implicit) into the file
- Actions will now get automatic weekly PRs when new versions are available — no more manual Node runtime hunts

## Test plan
- [ ] Confirm Dependabot picks up actions on next weekly run