### PR TITLE
fix(workflow): use GITHUB_TOKEN for issue-upsert step in validate-urls

### DIFF
--- a/.github/workflows/validate-urls.yml
+++ b/.github/workflows/validate-urls.yml
@@ -259,11 +259,19 @@ jobs:
             src/main/data/docs
             src/main/reports/url_validate_normalize.json
 
-      - name: Upsert URL issues 
+      - name: Upsert URL issues
+        # Uses the workflow's GITHUB_TOKEN (which already has issues:write per
+        # the top-level `permissions:` block) rather than the App token. The
+        # App token mint above is kept for steps that need bot-identity
+        # commits, but issue management against `actions/github-script` only
+        # needs `issues: write` — GITHUB_TOKEN's scope is sufficient and
+        # avoids the 401 path when the App's installation permissions drift
+        # (which is what caused run #27727667119 to fail with "Bad credentials"
+        # on issues.listForRepo).
         if: (success() || failure()) && steps.guard.outputs.skip != 'true'
         uses: actions/github-script@v9
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const path = require('path');


### PR DESCRIPTION
## Summary

`Validate URLs` workflow run [#27727667119](https://github.com/PrZ3r/MSRBot.io/actions/runs/27727667119) failed with a `HttpError: Bad credentials` 401 on `github.rest.issues.listForRepo` inside the "Upsert URL issues" step. The step had been minting a PrZ3 Unit App token and passing that to `actions/github-script@v9`; the App's installation permissions on this repo apparently drifted such that the resulting token no longer carries `issues: write`. Net effect: the workflow dies right at the point where it tries to publish URL-issue findings as GitHub issues, which is the whole reason the step exists.

## Fix

Switch the "Upsert URL issues" step from the App token to GITHUB_TOKEN. The workflow already grants `issues: write` to GITHUB_TOKEN at the job level (top-level `permissions:` block), so the script has the access it needs. GITHUB_TOKEN is immune to whatever drifted on the App's installation config.

Other steps in the same workflow that legitimately need the App token (auto-commit-back-to-main, create-pull-request, checkout with push) are unchanged — those need bot identity for git authorship and aren't on the 401 path.

## Out of scope

- The `Input 'app-id' has been deprecated; use 'client-id' instead` warning that surfaced in the same failed run is a non-blocking advisory from `actions/create-github-app-token@v3` — both inputs still work in v3. Migrating the repo secret from `APP_ID` (numeric) to `APP_CLIENT_ID` (`Iv23li…` format) is a separate follow-up if/when convenient. Not affecting the current bork.
- Other workflows (`extract-docs-*`, `build-master-*-index`, `pr-build-preview`, etc.) using the same App-token pattern aren't failing today — left alone to keep this change tightly scoped to the actual breakage.

## Test plan

- [x] Diff confined to one step in `.github/workflows/validate-urls.yml`
- [x] Top-level `permissions:` block already includes `issues: write` (verified at line 15 of the workflow)
- [ ] Next scheduled `Validate URLs` run completes successfully end-to-end
- [ ] "Upsert URL issues" step produces no 401 against the issues API
