### PR TITLE
fix(registry): patch index in place on saveDoc instead of full rebuild per write

### DIFF
--- a/src/main/lib/registry.js
+++ b/src/main/lib/registry.js
@@ -217,7 +217,13 @@ function saveDoc(doc) {
   fs.mkdirSync(path.dirname(target), { recursive: true });
   fs.writeFileSync(target, JSON.stringify(doc, null, 2) + '\n');
 
-  invalidateIndex();
+  // Incrementally update the index rather than invalidating it. getIndex()
+  // above already materialized _index, so we patch the single affected entry
+  // (docId -> new path) in place. Blowing the whole index away here forced the
+  // *next* saveDoc() to re-walk and re-parse the entire ~26k-file corpus, which
+  // turned any save loop (e.g. url.normalize --apply) into O(docs × corpus) and
+  // wedged CI for hours. Patching one key keeps a save loop O(docs).
+  _index.set(String(doc.docId), target);
   return { path: target, created, rehomed };
 }
 


### PR DESCRIPTION
## Problem

The **Validate Document URLs** workflow wedged in CI — one run sat in the `node src/main/scripts/url.normalize.js --apply` step for **3h35m** before being cancelled (it would otherwise have hit GitHub's hard 6h job cap). The URL validation itself finished normally; the hang was entirely in the post-validation backfill.

## Root cause

A migration artifact from the per-doc shard inversion (#1108, `b528a4d`, v2.0.0), which introduced the `saveDoc`/`loadDoc` + memoized docId→path index machinery.

`saveDoc()` called `invalidateIndex()` after every write, forcing the **next** `saveDoc()` to rebuild the index by re-walking and re-parsing the entire ~26,445-file registry (`buildIndex`). Any save *loop* therefore became **O(docs × corpus)**:

```js
for (const d of docs) {
  if (touched.has(d.docId)) { saveDoc(d); saved++; }  // each save -> full 26k-file re-walk
}
```

`url.normalize --apply` is the only validation-driven writer, and it backfills the full `redirect.undefined` set (thousands of docs) -> thousands × 26k file parses -> hours. The same latent defect existed in every other `saveDoc` caller (extraction, the SMPTE extractors, `new-doc.js`, etc.); they survived only because their per-run change sets are small.

## Fix

`getIndex()` at the top of `saveDoc` already materializes the index, so patch the single affected `docId -> path` entry in place instead of invalidating the whole thing. Rehoming keeps the same `docId`, so the entry is correctly overwritten.

## Verification

- `npm test` (registry smoke tests) passes
- Round-trip read-after-write correct, including the rehome case
- **50 writes across the 26,445-doc corpus: ~5ms** (was a full 26k-file rebuild per write)
- Working tree clean apart from the logic change — no doc reformatting drift

Speeds up every `saveDoc` caller, not just normalize.
