### PR TITLE
fix(ci): drop removed badRefs.latest.json from extract workflows

### DIFF
--- a/.github/workflows/extract-docs-ietf.yml
+++ b/.github/workflows/extract-docs-ietf.yml
@@ -124,7 +124,6 @@ jobs:
           git config user.name "PrZ3 Unit"
           git config user.email "prz3-unit[bot]@users.noreply.github.com"
           git add src/main/logs/extract-runs/pr-log-full-*.log
-          git add src/main/reports/badRefs.latest.json
           git diff --cached --quiet || git commit -m "Add PR update details file"
 
       - name: Resolve details file & blob SHA
@@ -182,7 +181,6 @@ jobs:
           add-paths: |
             src/main/data/docs
             src/main/reports/masterReferenceIndex.json
-            src/main/reports/badRefs.latest.json
           base: main
 
       # NEW: rewrite the PR body to use the PR Files diff anchor (not the raw URL)

--- a/.github/workflows/extract-docs-smpte.yml
+++ b/.github/workflows/extract-docs-smpte.yml
@@ -124,7 +124,6 @@ jobs:
           git config user.name "PrZ3 Unit"
           git config user.email "prz3-unit[bot]@users.noreply.github.com"
           git add src/main/logs/extract-runs/pr-log-full-*.log
-          git add src/main/reports/badRefs.latest.json
           git diff --cached --quiet || git commit -m "Add PR update details file"
 
       - name: Resolve details file & blob SHA
@@ -182,7 +181,6 @@ jobs:
           add-paths: |
             src/main/data/docs
             src/main/reports/masterReferenceIndex.json
-            src/main/reports/badRefs.latest.json
           base: main
 
       # NEW: rewrite the PR body to use the PR Files diff anchor (not the raw URL)


### PR DESCRIPTION
## Problem

`badRefs.latest.json` was removed as an MRI output (the legacy sidecar persistence is gone — see comments in `extractDocs.js`), but both extract workflows still referenced the file. The **Commit PR update details file** step ran:

```bash
git add src/main/reports/badRefs.latest.json
```

which fails with `fatal: pathspec 'src/main/reports/badRefs.latest.json' did not match any files` → **exit 128**, breaking the scheduled SMPTE and IETF extract runs (e.g. [run 27933060518](https://github.com/PrZ3r/MSRBot.io/actions/runs/27933060518/job/82648755801)).

## Fix

Removed the stale `badRefs.latest.json` reference from **both** extract workflows, in two places each:
1. the `git add` in *Commit PR update details file*
2. the `add-paths:` list in *Commit and create PR* (peter-evans)

Verified no `badRefs` references remain in `.github/workflows/`. The file is untracked/absent and nothing writes it anymore, so these were pure dead references.

## Notes / out of scope

- `src/main/scripts/utils/review.refs.js` still *reads* `badRefs.latest.json` (a dev-only diagnostic) — harmless, it just finds nothing. Left as-is.
- The same step still `git add`s `pr-log-full-*.log`; that glob currently matches (extraction writes the log), so it's unaffected — but it would fail the same way if a run ever produced no log. Not touched here to stay scoped to the badRefs regression.
