### PR TITLE
chore: remove CSV exports, drop json-2-csv dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "bootstrap-icons": "^1.9.1",
         "cheerio": "^1.2.0",
         "dayjs": "^1.11.20",
-        "json-2-csv": "^3.17.1",
         "json-source-map": "^0.6.1",
         "json-stable-stringify": "^1.0.1",
         "minisearch": "^7.2.0",
@@ -254,15 +253,6 @@
       "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
       "license": "MIT"
     },
-    "node_modules/deeks": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/deeks/-/deeks-2.6.1.tgz",
-      "integrity": "sha512-PZrpz5xLo2JPZa3L+kqMMMdZU5pRwMysTM1xd6pLhNtgQw4Iq3wbF2QWaQTVh+HRq9Yg4rcjDIJ+scfGLxmsjQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -287,15 +277,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/doc-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/doc-path/-/doc-path-3.1.0.tgz",
-      "integrity": "sha512-Pv2hLQbUM8du5681lTWIYk0OtVBmNhMAeZNGeFhMMJBIR89Nw4XesBwee1Xtlfk83n71tn0Y6VsJOn4d3qIiTw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/dom-serializer": {
@@ -702,19 +683,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "license": "MIT"
-    },
-    "node_modules/json-2-csv": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/json-2-csv/-/json-2-csv-3.20.0.tgz",
-      "integrity": "sha512-IbqUB+yaycVNB/q2fiY5kyRjy5kRiEXqvNvGlxM5L0Bfi0RdvklVHc4t9MfeYF1GsZVpZWDBs9LdWmSjsQ8jvg==",
-      "license": "MIT",
-      "dependencies": {
-        "deeks": "2.6.1",
-        "doc-path": "3.1.0"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "bootstrap-icons": "^1.9.1",
     "cheerio": "^1.2.0",
     "dayjs": "^1.11.20",
-    "json-2-csv": "^3.17.1",
     "json-source-map": "^0.6.1",
     "json-stable-stringify": "^1.0.1",
     "minisearch": "^7.2.0",

--- a/src/main/scripts/build.js
+++ b/src/main/scripts/build.js
@@ -125,9 +125,6 @@ hb.registerHelper('mriCite', function (refId) {
     : inner;
   return new hb.SafeString(`<cite>${body}</cite>`);
 });
-const { readFile } = fs; // promises readFile
-const { json2csvAsync } = require('json-2-csv');
-
 // Server-side helper to pass through raw blocks used to embed client-side templates
 hb.registerHelper('raw', function(options) {
   return new hb.SafeString(options.fn(this));
@@ -1123,14 +1120,9 @@ async function buildRegistry ({ listType, templateType, templateName, idType, li
   const ogImageAlt = siteConfig.ogImageAlt;
   // Asset prefix for relative local assets in header/footer
   const assetPrefix = '../';
-  // Emit CSV into the shared /_data/ folder so all pages can link to a single canonical export.
-  // Example outputs:
-  //   build/_data/documents.csv
-  //   build/_data/groups.csv
-  //   build/_data/projects.csv
-  var CSV_SITE_PATH = "_data/" + templateType + ".csv";
-  const inputFileName = DATA_PATH;
-  const outputFileName = BUILD_PATH + "/" + CSV_SITE_PATH;
+  // Legacy CSV path retained as a stub that points consumers at the JSON API.
+  const CSV_SITE_PATH = "_data/" + templateType + ".csv";
+  const csvStubPath = BUILD_PATH + "/" + CSV_SITE_PATH;
 
   /* load header and footer for templates */
   hb.registerPartial('header', await fs.readFile("src/main/templates/partials/header.hbs", 'utf8'));
@@ -3041,7 +3033,6 @@ hb.registerHelper('docProjLookup', function(collection, id) {
       "docProjs": docProjs,
       "htmlLink": htmlLink,
       "date" :  new Date(),
-      "csv_path": CSV_SITE_PATH,
       "site_version": site_version,
       "listType": listType,
       "idType": idType,
@@ -3353,35 +3344,21 @@ hb.registerHelper('docProjLookup', function(collection, id) {
     pptr_options.executablePath = process.env.CHROMEPATH;
   }
 
-  async function parseJSONFile (fileName) {
-    try {
-      const file = await readFile(fileName);
-      return JSON.parse(file);
-    } catch (err) {
-      console.log(err);
-      process.exit(1);
-    }
-  }
-
-  async function writeCSV (fileName, data) {
-    await writeFileSafe(fileName, data, 'utf8');
-  }
-
+  // Legacy CSV export was removed once /api/*.json covered the same surface.
+  // Emit a tiny CSV-shaped stub at the old path so bookmarks land on a
+  // machine-readable pointer to the JSON replacement instead of a raw 404.
   (async () => {
-    // The documents registry is a directory of per-doc files (issue #1108);
-    // use the already-loaded in-memory array instead of reading a monolith.
-    const data = (listType === 'documents')
-      ? registryDocument
-      : await parseJSONFile(inputFileName);
-    // Remove all fields where the key contains "$meta" before exporting to CSV
-    const stripped = JSON.parse(
-      JSON.stringify(
-        data,
-        (key, val) => (typeof key === 'string' && key.includes('$meta') ? undefined : val)
-      )
-    );
-    const csv = await json2csvAsync(stripped);
-    await writeCSV(outputFileName, csv);
+    const jsonPointer = templateType === 'documents'
+      ? '/api/documents.json'
+      : templateType === 'groups'
+        ? '/groups/_data/groups.json'
+        : templateType === 'projects'
+          ? '/projects/_data/projects.json'
+          : `/_data/${templateType}.json`;
+    const stub =
+      'notice,new_location\n' +
+      `"This CSV export has been removed. Use the JSON endpoint instead.","${jsonPointer}"\n`;
+    await writeFileSafe(csvStubPath, stub, 'utf8');
   })();
 
   console.log(`Build of ${templateName} completed`)
@@ -3430,7 +3407,6 @@ void (async () => {
     listTitle: 'Docs',
     htmlLink: '', // same relative handling as other pages
     listType: 'documents',
-    csv_path: 'documents.csv',
     site_version: (await execFile('git', ['rev-parse','HEAD'])).stdout.trim(),
     date: new Date().toISOString(),
     // meta

--- a/src/main/templates/partials/header.hbs
+++ b/src/main/templates/partials/header.hbs
@@ -259,28 +259,6 @@
         </li>
       </ul>
 
-      <strong>CSV exports</strong>
-      <ul class="mb-2">
-        <li>
-          <a href="{{assetPrefix}}_data/documents.csv" target="_blank" rel="noopener">
-            documents.csv
-          </a>
-          &mdash; flat document CSV export
-        </li>
-        <li>
-          <a href="{{assetPrefix}}_data/groups.csv" target="_blank" rel="noopener">
-            groups.csv
-          </a>
-          &mdash; flat groups CSV export
-        </li>
-        <li>
-          <a href="{{assetPrefix}}_data/projects.csv" target="_blank" rel="noopener">
-            projects.csv
-          </a>
-          &mdash; flat projects CSV export
-        </li>
-      </ul>
-
       <strong>Resources</strong>
       <ul class="mb-0">
         <li>


### PR DESCRIPTION
## Summary
- Drops `json-2-csv` entirely — the `/api/*.json` surface (per-doc files, documents index, mri-cite-map, stats) covers everything the flat CSV exports did.
- Legacy `/_data/{documents,groups,projects}.csv` URLs still emit a tiny two-line CSV stub pointing at the JSON replacement, so external bookmarks land on a machine-readable pointer instead of a 404.
- Removes the "CSV exports" section from the header dropdown; the JSON links directly above it stay.
- Also unblocks closing #1224 (which tried to bump `json-2-csv` across two majors and hit an API-shape break on `json2csvAsync`).

## Test plan
- [x] `npm run build` succeeds end-to-end locally
- [x] `build/_data/{documents,groups,projects}.csv` are emitted as stubs with the correct JSON pointers
- [x] PR Build Preview passes in CI
- [x] Visual sanity check on the deployed preview — confirm the header dropdown no longer shows "CSV exports"