### PR TITLE
feat(audit): FTXML ref extractor — backfill 2,995 refs onto the ingested docs

### DIFF
--- a/src/main/reports/smpte-canonical-audit/ftxmlRefApply.json
+++ b/src/main/reports/smpte-canonical-audit/ftxmlRefApply.json
@@ -1,0 +1,693 @@
+{
+  "generatedAt": "2026-07-20T17:25:52.998Z",
+  "apply": false,
+  "limit": null,
+  "totals": {
+    "ftxmlFilesWithRefs": 168,
+    "sourceDocsTouched": 167,
+    "refsProcessed": 2995,
+    "canonical": 40,
+    "canonicalInRegistry": 40,
+    "canonicalKnownNoDoc": 0,
+    "orphanSlugs": 2955,
+    "docsWritten": 0,
+    "unmappedFiles": 0
+  },
+  "byVia": {
+    "orphan-slug": 2953,
+    "direct-doi": 32,
+    "vol+pages": 6,
+    "mapRefByCite": 2,
+    "vol+pages-ambiguous": 2
+  },
+  "perDoc": [
+    {
+      "docId": "10.5594-JMI.2024-EBVF7405",
+      "refCount": 15
+    },
+    {
+      "docId": "10.5594-JMI.2024-YQTR8645",
+      "refCount": 5
+    },
+    {
+      "docId": "10.5594-JMI.2024-JUNZ2729",
+      "refCount": 28
+    },
+    {
+      "docId": "10.5594-JMI.2024-LHXY3357",
+      "refCount": 45
+    },
+    {
+      "docId": "10.5594-JMI.2024-MRLF3850",
+      "refCount": 71
+    },
+    {
+      "docId": "10.5594-JMI.2024-INNK6533",
+      "refCount": 2
+    },
+    {
+      "docId": "10.5594-JMI.2024-QHIF9784",
+      "refCount": 15
+    },
+    {
+      "docId": "10.5594-JMI.2024-DPLO3149",
+      "refCount": 12
+    },
+    {
+      "docId": "10.5594-JMI.2024-OFBT6040",
+      "refCount": 22
+    },
+    {
+      "docId": "10.5594-JMI.2024-HWAR6964",
+      "refCount": 6
+    },
+    {
+      "docId": "10.5594-JMI.2024-IHPC9661",
+      "refCount": 15
+    },
+    {
+      "docId": "10.5594-JMI.2024-GZSR2120",
+      "refCount": 11
+    },
+    {
+      "docId": "10.5594-JMI.2024-IXTK5404",
+      "refCount": 25
+    },
+    {
+      "docId": "10.5594-JMI.2024-HSKL1799",
+      "refCount": 9
+    },
+    {
+      "docId": "10.5594-JMI.2024-ZRBF6236",
+      "refCount": 16
+    },
+    {
+      "docId": "10.5594-JMI.2024-DMCG7001",
+      "refCount": 7
+    },
+    {
+      "docId": "10.5594-JMI.2024-DHPI3162",
+      "refCount": 12
+    },
+    {
+      "docId": "10.5594-JMI.2024-NQQJ1648",
+      "refCount": 10
+    },
+    {
+      "docId": "10.5594-JMI.2024-RLWZ3064",
+      "refCount": 11
+    },
+    {
+      "docId": "10.5594-JMI.2024-WREN8857",
+      "refCount": 38
+    },
+    {
+      "docId": "10.5594-JMI.2024-EDTJ6242",
+      "refCount": 12
+    },
+    {
+      "docId": "10.5594-JMI.2024-DDLP8310",
+      "refCount": 16
+    },
+    {
+      "docId": "10.5594-JMI.2024-KFLQ4529",
+      "refCount": 8
+    },
+    {
+      "docId": "10.5594-JMI.2024-WSSG3140",
+      "refCount": 23
+    },
+    {
+      "docId": "10.5594-JMI.2024-TPSA1162",
+      "refCount": 14
+    },
+    {
+      "docId": "10.5594-JMI.2024-SJIL4746",
+      "refCount": 27
+    },
+    {
+      "docId": "10.5594-JMI.2024-NYYP7085",
+      "refCount": 7
+    },
+    {
+      "docId": "10.5594-JMI.2024-WYOR1428",
+      "refCount": 14
+    },
+    {
+      "docId": "10.5594-JMI.2024-XERC8120",
+      "refCount": 25
+    },
+    {
+      "docId": "10.5594-JMI.2024-WAWA6631",
+      "refCount": 24
+    },
+    {
+      "docId": "10.5594-JMI.2024-ORAX6147",
+      "refCount": 10
+    },
+    {
+      "docId": "10.5594-JMI.2024-YPJG9446",
+      "refCount": 36
+    },
+    {
+      "docId": "10.5594-JMI.2024-IEMT5198",
+      "refCount": 17
+    },
+    {
+      "docId": "10.5594-JMI.2024-BZSK5411",
+      "refCount": 21
+    },
+    {
+      "docId": "10.5594-JMI.2024-XBZC2345",
+      "refCount": 23
+    },
+    {
+      "docId": "10.5594-JMI.2024-IPYX8877__2024-SMPTEMIJAPRIL2024_18-18",
+      "refCount": 80
+    },
+    {
+      "docId": "10.5594-JMI.2024-RSMP6989",
+      "refCount": 16
+    },
+    {
+      "docId": "10.5594-JMI.2024-IIOY7619",
+      "refCount": 8
+    },
+    {
+      "docId": "10.5594-JMI.2024-NMRU3069",
+      "refCount": 17
+    },
+    {
+      "docId": "10.5594-JMI.2024-IDFE7786",
+      "refCount": 26
+    },
+    {
+      "docId": "10.5594-JMI.2024-AMRD2656",
+      "refCount": 3
+    },
+    {
+      "docId": "10.5594-JMI.2024-INHO8299",
+      "refCount": 12
+    },
+    {
+      "docId": "10.5594-JMI.2025-RRZQ5919",
+      "refCount": 22
+    },
+    {
+      "docId": "10.5594-JMI.2025-ADND9644",
+      "refCount": 5
+    },
+    {
+      "docId": "10.5594-JMI.2025-WSWP2953",
+      "refCount": 6
+    },
+    {
+      "docId": "10.5594-JMI.2025-GGBP2184",
+      "refCount": 16
+    },
+    {
+      "docId": "10.5594-JMI.2025-XEJK1138",
+      "refCount": 16
+    },
+    {
+      "docId": "10.5594-JMI.2025-JCRG7496",
+      "refCount": 24
+    },
+    {
+      "docId": "10.5594-JMI.2025-BBXM4789",
+      "refCount": 18
+    },
+    {
+      "docId": "10.5594-JMI.2025-NNRR2188",
+      "refCount": 52
+    },
+    {
+      "docId": "10.5594-JMI.2025-CVFK2383",
+      "refCount": 7
+    },
+    {
+      "docId": "10.5594-JMI.2025-MKDM4311",
+      "refCount": 6
+    },
+    {
+      "docId": "10.5594-JMI.2025-GLNG7938",
+      "refCount": 26
+    },
+    {
+      "docId": "10.5594-JMI.2025-LZES6606",
+      "refCount": 11
+    },
+    {
+      "docId": "10.5594-JMI.2025-RDCU7256",
+      "refCount": 43
+    },
+    {
+      "docId": "10.5594-JMI.2025-LGJX4897",
+      "refCount": 8
+    },
+    {
+      "docId": "10.5594-JMI.2025-NSNH7881",
+      "refCount": 26
+    },
+    {
+      "docId": "10.5594-JMI.2025-LWQF4260",
+      "refCount": 7
+    },
+    {
+      "docId": "10.5594-JMI.2025-OSES1593",
+      "refCount": 14
+    },
+    {
+      "docId": "10.5594-JMI.2025-MBQP3310",
+      "refCount": 14
+    },
+    {
+      "docId": "10.5594-JMI.2025-PGRJ7276",
+      "refCount": 11
+    },
+    {
+      "docId": "10.5594-JMI.2025-EWDC4700",
+      "refCount": 14
+    },
+    {
+      "docId": "10.5594-JMI.2025-XXLK4545",
+      "refCount": 15
+    },
+    {
+      "docId": "10.5594-JMI.2025-BTRS5498",
+      "refCount": 17
+    },
+    {
+      "docId": "10.5594-JMI.2025-MJPY7062",
+      "refCount": 22
+    },
+    {
+      "docId": "10.5594-JMI.2025-ZXXM9513",
+      "refCount": 23
+    },
+    {
+      "docId": "10.5594-JMI.2025-FRWU1305",
+      "refCount": 18
+    },
+    {
+      "docId": "10.5594-JMI.2025-FMBA2236",
+      "refCount": 12
+    },
+    {
+      "docId": "10.5594-JMI.2025-TZCE1835",
+      "refCount": 14
+    },
+    {
+      "docId": "10.5594-JMI.2025-OJUX5368",
+      "refCount": 37
+    },
+    {
+      "docId": "10.5594-JMI.2025-DSKU9413",
+      "refCount": 70
+    },
+    {
+      "docId": "10.5594-JMI.2025-SACY7493",
+      "refCount": 19
+    },
+    {
+      "docId": "10.5594-JMI.2025-OJDI1382",
+      "refCount": 9
+    },
+    {
+      "docId": "10.5594-JMI.2025-FOOS6445",
+      "refCount": 38
+    },
+    {
+      "docId": "10.5594-JMI.2025-BDAV7562",
+      "refCount": 73
+    },
+    {
+      "docId": "10.5594-JMI.2025-FVEV7398",
+      "refCount": 9
+    },
+    {
+      "docId": "10.5594-JMI.2025-NYXN3212",
+      "refCount": 17
+    },
+    {
+      "docId": "10.5594-JMI.2025-NUGE5689",
+      "refCount": 34
+    },
+    {
+      "docId": "10.5594-JMI.2025-LSTI9879",
+      "refCount": 19
+    },
+    {
+      "docId": "10.5594-JMI.2025-MPAJ5620",
+      "refCount": 23
+    },
+    {
+      "docId": "10.5594-JMI.2025-MUNU2550",
+      "refCount": 18
+    },
+    {
+      "docId": "10.5594-JMI.2026-JORP7004",
+      "refCount": 33
+    },
+    {
+      "docId": "10.5594-JMI.2026-YEXQ9772",
+      "refCount": 14
+    },
+    {
+      "docId": "10.5594-JMI.2026-STQB7558",
+      "refCount": 11
+    },
+    {
+      "docId": "10.5594-JMI.2026-YPFV5033",
+      "refCount": 13
+    },
+    {
+      "docId": "10.5594-JMI.2026-RRHS3606",
+      "refCount": 15
+    },
+    {
+      "docId": "10.5594-JMI.2026-AAZW6907",
+      "refCount": 19
+    },
+    {
+      "docId": "10.5594-JMI.2026-DVMH6152",
+      "refCount": 13
+    },
+    {
+      "docId": "10.5594-JMI.2026-IZOS7458",
+      "refCount": 5
+    },
+    {
+      "docId": "10.5594-JMI.2026-YBXS2540",
+      "refCount": 9
+    },
+    {
+      "docId": "10.5594-JMI.2026-YGPF6760",
+      "refCount": 36
+    },
+    {
+      "docId": "10.5594-JMI.2026-YOXS1352",
+      "refCount": 29
+    },
+    {
+      "docId": "10.5594-JMI.2026-TEYI3961",
+      "refCount": 24
+    },
+    {
+      "docId": "10.5594-JMI.2026-CKZU8948",
+      "refCount": 17
+    },
+    {
+      "docId": "10.5594-JMI.2026-KRQD4667",
+      "refCount": 9
+    },
+    {
+      "docId": "10.5594-JMI.2026-HLCK3638",
+      "refCount": 13
+    },
+    {
+      "docId": "10.5594-MOO-3001",
+      "refCount": 15
+    },
+    {
+      "docId": "10.5594-MOO-3010",
+      "refCount": 73
+    },
+    {
+      "docId": "10.5594-MOO-3011",
+      "refCount": 22
+    },
+    {
+      "docId": "10.5594-MOO-3012",
+      "refCount": 1
+    },
+    {
+      "docId": "10.5594-MOO-3013",
+      "refCount": 16
+    },
+    {
+      "docId": "10.5594-MOO-3014",
+      "refCount": 17
+    },
+    {
+      "docId": "10.5594-MOO-3015",
+      "refCount": 9
+    },
+    {
+      "docId": "10.5594-MOO-3016",
+      "refCount": 16
+    },
+    {
+      "docId": "10.5594-MOO-3017",
+      "refCount": 7
+    },
+    {
+      "docId": "10.5594-MOO-3018",
+      "refCount": 14
+    },
+    {
+      "docId": "10.5594-MOO-3019",
+      "refCount": 4
+    },
+    {
+      "docId": "10.5594-MOO-3002",
+      "refCount": 3
+    },
+    {
+      "docId": "10.5594-MOO-3020",
+      "refCount": 3
+    },
+    {
+      "docId": "10.5594-MOO-3021",
+      "refCount": 14
+    },
+    {
+      "docId": "10.5594-MOO-3022",
+      "refCount": 15
+    },
+    {
+      "docId": "10.5594-MOO-3033",
+      "refCount": 4
+    },
+    {
+      "docId": "10.5594-MOO-3034",
+      "refCount": 33
+    },
+    {
+      "docId": "10.5594-MOO-3035",
+      "refCount": 34
+    },
+    {
+      "docId": "10.5594-MOO-3036",
+      "refCount": 6
+    },
+    {
+      "docId": "10.5594-MOO-3037",
+      "refCount": 11
+    },
+    {
+      "docId": "10.5594-MOO-3038",
+      "refCount": 2
+    },
+    {
+      "docId": "10.5594-MOO-3039",
+      "refCount": 5
+    },
+    {
+      "docId": "10.5594-MOO-3003",
+      "refCount": 11
+    },
+    {
+      "docId": "10.5594-MOO-3041",
+      "refCount": 16
+    },
+    {
+      "docId": "10.5594-MOO-3042",
+      "refCount": 13
+    },
+    {
+      "docId": "10.5594-MOO-3043",
+      "refCount": 16
+    },
+    {
+      "docId": "10.5594-MOO-3044",
+      "refCount": 6
+    },
+    {
+      "docId": "10.5594-MOO-3045",
+      "refCount": 1
+    },
+    {
+      "docId": "10.5594-MOO-3046",
+      "refCount": 9
+    },
+    {
+      "docId": "10.5594-MOO-3047",
+      "refCount": 5
+    },
+    {
+      "docId": "10.5594-MOO-3048",
+      "refCount": 23
+    },
+    {
+      "docId": "10.5594-MOO-3049",
+      "refCount": 8
+    },
+    {
+      "docId": "10.5594-MOO-3040",
+      "refCount": 23
+    },
+    {
+      "docId": "10.5594-MOO-3004",
+      "refCount": 23
+    },
+    {
+      "docId": "10.5594-MOO-3050",
+      "refCount": 43
+    },
+    {
+      "docId": "10.5594-MOO-3005",
+      "refCount": 33
+    },
+    {
+      "docId": "10.5594-MOO-3006",
+      "refCount": 20
+    },
+    {
+      "docId": "10.5594-MOO-3007",
+      "refCount": 24
+    },
+    {
+      "docId": "10.5594-MOO-3008",
+      "refCount": 9
+    },
+    {
+      "docId": "10.5594-MOO-3009",
+      "refCount": 11
+    },
+    {
+      "docId": "978-1-61482-966-9-1",
+      "refCount": 12
+    },
+    {
+      "docId": "978-1-61482-966-9-10",
+      "refCount": 5
+    },
+    {
+      "docId": "978-1-61482-966-9-11",
+      "refCount": 5
+    },
+    {
+      "docId": "978-1-61482-966-9-12",
+      "refCount": 29
+    },
+    {
+      "docId": "978-1-61482-966-9-13",
+      "refCount": 23
+    },
+    {
+      "docId": "978-1-61482-966-9-14",
+      "refCount": 32
+    },
+    {
+      "docId": "978-1-61482-966-9-15",
+      "refCount": 10
+    },
+    {
+      "docId": "978-1-61482-966-9-18",
+      "refCount": 18
+    },
+    {
+      "docId": "978-1-61482-966-9-19",
+      "refCount": 23
+    },
+    {
+      "docId": "978-1-61482-966-9-2",
+      "refCount": 13
+    },
+    {
+      "docId": "978-1-61482-966-9-20",
+      "refCount": 20
+    },
+    {
+      "docId": "978-1-61482-966-9-21",
+      "refCount": 30
+    },
+    {
+      "docId": "978-1-61482-966-9-22",
+      "refCount": 5
+    },
+    {
+      "docId": "978-1-61482-966-9-23",
+      "refCount": 3
+    },
+    {
+      "docId": "978-1-61482-966-9-24",
+      "refCount": 2
+    },
+    {
+      "docId": "978-1-61482-966-9-25",
+      "refCount": 11
+    },
+    {
+      "docId": "978-1-61482-966-9-26",
+      "refCount": 4
+    },
+    {
+      "docId": "978-1-61482-966-9-27",
+      "refCount": 5
+    },
+    {
+      "docId": "978-1-61482-966-9-28",
+      "refCount": 14
+    },
+    {
+      "docId": "978-1-61482-966-9-29",
+      "refCount": 47
+    },
+    {
+      "docId": "978-1-61482-966-9-3",
+      "refCount": 8
+    },
+    {
+      "docId": "978-1-61482-966-9-30",
+      "refCount": 17
+    },
+    {
+      "docId": "978-1-61482-966-9-31",
+      "refCount": 8
+    },
+    {
+      "docId": "978-1-61482-966-9-32",
+      "refCount": 7
+    },
+    {
+      "docId": "978-1-61482-966-9-33",
+      "refCount": 8
+    },
+    {
+      "docId": "978-1-61482-966-9-36",
+      "refCount": 16
+    },
+    {
+      "docId": "978-1-61482-966-9-4",
+      "refCount": 18
+    },
+    {
+      "docId": "978-1-61482-966-9-5",
+      "refCount": 8
+    },
+    {
+      "docId": "978-1-61482-966-9-6",
+      "refCount": 11
+    },
+    {
+      "docId": "978-1-61482-966-9-7",
+      "refCount": 6
+    },
+    {
+      "docId": "978-1-61482-966-9-8",
+      "refCount": 16
+    }
+  ]
+}

--- a/src/main/reports/smpte-canonical-audit/ftxmlRefApply.md
+++ b/src/main/reports/smpte-canonical-audit/ftxmlRefApply.md
@@ -1,0 +1,31 @@
+# FTXML reference apply — backfill onto the 491 ingested docs
+
+> DRY-RUN · 2026-07-20T17:25:52.998Z
+
+## Totals
+- FTXML files with refs      : 168
+- source docs touched        : **167**
+- refs processed             : **2995**
+- → canonical refId (direct link) : **40** (40 resolve to a registry doc)
+- → orphan slug (MRI, EXTERNAL badge) : **2955**
+- unmapped FTXML files       : 0
+- docs written               : 0
+
+## By resolution path
+| path | refs |
+|---|---:|
+| `orphan-slug` | 2953 |
+| `direct-doi` | 32 |
+| `vol+pages` | 6 |
+| `mapRefByCite` | 2 |
+| `vol+pages-ambiguous` | 2 |
+
+## Notes
+- Source docs are mapped through the **content_batch sibling**, not the FTXML `<article-id>`:
+  conference FTXML carry an empty article DOI, so an FTXML-DOI match strands all 76 of them.
+- `vol+pages` resolves SMPTE self-cites only on **unambiguous** keys; multi-hit keys fall through
+  to an orphan mint rather than guessing.
+- Orphan slugs are not silent: they render as `<cite>` with an EXTERNAL badge, carry the raw XML +
+  citation text in the MRI, and graduate to canonical refIds later via `resolveOrphans` with no
+  doc-file edits.
+- Targets were greenfield (0 of 491 carried references); existing refs are merged, never replaced.

--- a/src/main/scripts/extras/smpte-canonical-audit/extractFtxmlRefs.js
+++ b/src/main/scripts/extras/smpte-canonical-audit/extractFtxmlRefs.js
@@ -1,0 +1,342 @@
+/*
+ * extractFtxmlRefs.js — Todo #1 (apply half) of the canonical-audit handoff.
+ *
+ * ftxmlRefWalker.js cataloged 2,995 structured refs in the FTXML NLM full-text
+ * XMLs but could not route them: their source articles did not exist in the
+ * registry. PR #1241 ingested those 491 docs, so the refs can now be attached.
+ * All 289 FTXML files resolve to a real doc and all 2,995 refs are attachable.
+ *
+ * SOURCE-DOC MAPPING — the subtle part. Map each FTXML file to its doc via the
+ * SIBLING content_batch primary, NOT the FTXML's own <article-id>: conference
+ * FTXML carry an EMPTY article DOI, so matching on it strands all 76 conference
+ * papers. Sibling path is `.../FTXML/FT_<name>.xml` -> `.../<name>.xml`, and the
+ * docId is then the same key the ingester minted (DOI->dash, else ISBN/ISSN +
+ * article_sequence).
+ *
+ * RESOLUTION CHAIN per <ref> (Phase-3a pattern, extractSmpteJournalRefs.js):
+ *   1. direct DOI      — <pub-id pub-id-type="doi">, exact case (never lowercase
+ *                        a DOI join — canonical-audit rule)
+ *   2. vol+pages       — SMPTE self-cites: (volume, first_page) against the
+ *                        journal/conference corpus. Only UNAMBIGUOUS keys
+ *                        resolve; multi-hit keys fall through to orphan-mint
+ *                        rather than guess.
+ *   3. mapRefByCite    — refMap.json canonical-form entries (curated, exact)
+ *   4. orphan-slug     — content-hash pre-checked (#1229) MRI mint. Under MRI v2
+ *                        these are first-class: cited from the source doc,
+ *                        rendered with an EXTERNAL badge, carrying the raw XML +
+ *                        citation text, and able to graduate later via
+ *                        resolveOrphans without touching doc files.
+ *
+ * The #1229 content-hash pre-check: before minting, the raw <ref> XML is hashed
+ * and checked against existing MRI entries. A hash that already resolved to a
+ * canonical refId is reused as a direct link instead of minting a duplicate
+ * orphan — this is the leaked-slug / twin-pair class from the Phase-3a cleanup.
+ *
+ * Targets are greenfield: all 491 ingested docs carry zero references, so this
+ * only adds. Existing refs on any doc are never overwritten.
+ *
+ *   node …/extractFtxmlRefs.js            # dry-run -> report
+ *   node …/extractFtxmlRefs.js --apply    # write docs + MRI
+ *   node …/extractFtxmlRefs.js --limit 20 # cap to N source docs
+ *
+ * Reports: src/main/reports/smpte-canonical-audit/ftxmlRefApply.{json,md}
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { loadAllDocs, saveDoc } = require('../../../lib/registry');
+const {
+  mapRefByCite,
+  reloadRefMap,
+  mriRecordSighting,
+  mriFlush,
+  mriEnsureFile,
+  _contentHash,
+} = require('../../../lib/referencing');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..', '..');
+process.chdir(REPO_ROOT);
+
+const NOW = new Date().toISOString();
+const APPLY = process.argv.includes('--apply');
+const LIMIT = (() => {
+  const i = process.argv.indexOf('--limit');
+  if (i < 0) return 0;
+  const n = parseInt(process.argv[i + 1] || '', 10);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+})();
+
+const CATALOG = 'src/main/reports/smpte-canonical-audit/ftxmlRefCatalog.json';
+const MRI_PATH = 'src/main/reports/masterReferenceIndex.json';
+const OUT_JSON = 'src/main/reports/smpte-canonical-audit/ftxmlRefApply.json';
+const OUT_MD = 'src/main/reports/smpte-canonical-audit/ftxmlRefApply.md';
+
+// ---- XML helpers ---------------------------------------------------------
+function decodeEntities(s) {
+  return String(s || '')
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => { try { return String.fromCodePoint(parseInt(h, 16)); } catch { return ''; } })
+    .replace(/&#(\d+);/g, (_, d) => { try { return String.fromCodePoint(parseInt(d, 10)); } catch { return ''; } })
+    .replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&apos;/g, "'");
+}
+const strip = (s) => decodeEntities(String(s || '').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim());
+function tag(x, t) { const m = String(x).match(new RegExp(`<${t}\\b[^>]*>([\\s\\S]*?)</${t}>`, 'i')); return m ? m[1] : ''; }
+const tagText = (x, t) => strip(tag(x, t));
+function field(block, t) { const m = String(block).match(new RegExp(`<${t}\\b[^>]*>([\\s\\S]*?)</${t}>`, 'i')); return m ? strip(m[1]) : ''; }
+
+// ---- registry + indices --------------------------------------------------
+console.log('[ftxml-refs] loading registry…');
+reloadRefMap();
+mriEnsureFile();
+
+const docs = loadAllDocs();
+const byDocId = new Map(docs.map((d) => [d.docId, d]));
+const docIds = new Set(docs.map((d) => d.docId));
+// Exact-case DOI index — never lowercase a DOI join.
+const byDoi = new Map();
+for (const d of docs) if (d.doi) byDoi.set(String(d.doi).trim(), d);
+
+// vol+pages self-cite index; ambiguous keys are recorded so we can refuse them.
+const volPages = new Map();
+for (const d of docs) {
+  if (!/^10\.5594-[jJmM]/.test(d.docId || '')) continue;
+  if (!d.volume || !d.pages) continue;
+  const fp = String(d.pages).split(/[-–—]/)[0].trim();
+  const key = `${String(d.volume).trim()}|${fp}`;
+  if (!volPages.has(key)) volPages.set(key, []);
+  volPages.get(key).push(d.docId);
+}
+console.log(`[ftxml-refs]   vol+pages index: ${volPages.size} keys`);
+
+// #1229 content-hash pre-check — hash -> already-known canonical refId
+const hashToRefId = new Map();
+try {
+  const mri = JSON.parse(fs.readFileSync(MRI_PATH, 'utf8'));
+  for (const [refId, e] of Object.entries(mri.refs || {})) {
+    if (e && e.contentHash && !e.isOrphan) hashToRefId.set(e.contentHash, refId);
+  }
+} catch (e) { console.warn(`[ftxml-refs]   MRI preload skipped: ${e.message}`); }
+console.log(`[ftxml-refs]   content-hash pre-check entries: ${hashToRefId.size}`);
+
+// ---- source-doc mapping (via the content_batch sibling) ------------------
+function docForFtxml(ftxmlPath) {
+  const sib = ftxmlPath.replace(/\/FTXML\/FT_/, '/');
+  let xml; try { xml = fs.readFileSync(sib, 'utf8'); } catch { return null; }
+  const isConf = /<conference_article\b/.test(xml);
+  const art = tag(xml, isConf ? 'conference_article' : 'journal_article');
+  if (!art) return null;
+
+  const doi = tagText(art, 'doi');
+  if (doi && byDoi.has(doi)) return byDoi.get(doi);
+
+  const seq = tagText(art, 'article_sequence') || '0';
+  if (isConf) {
+    const isbn = tagText(tag(xml, 'conference_metadata'), 'isbn');
+    return byDocId.get(`${isbn}-${seq}`) || null;
+  }
+  const meta = tag(xml, 'journal_metadata');
+  const issn = (meta.match(/<issn[^>]*type="electronic"[^>]*>([^<]+)<\/issn>/i) || [])[1];
+  const jv = tag(tag(xml, 'journal_issue'), 'journal_volume');
+  return byDocId.get(`${issn}-v${tagText(jv, 'volume')}.${tagText(jv, 'issue')}-${seq}`) || null;
+}
+
+// ---- resolution chain ----------------------------------------------------
+function isSmpteJournalSource(src) {
+  const s = String(src || '').toLowerCase().trim();
+  return /^journal$/.test(s) || /smp[te]|soc.*mot|trans.*mot/.test(s);
+}
+
+function resolve(rawRef) {
+  // 1. direct DOI (exact case)
+  const doi = (rawRef.match(/<pub-id[^>]*pub-id-type=["']doi["'][^>]*>([^<]+)<\/pub-id>/i) || [])[1];
+  if (doi) {
+    const t = doi.trim();
+    if (byDoi.has(t)) return { kind: 'canonical', refId: byDoi.get(t).docId, via: 'direct-doi' };
+    const dashed = t.replace(/\//g, '-');
+    if (docIds.has(dashed)) return { kind: 'canonical', refId: dashed, via: 'direct-doi' };
+  }
+
+  const source = field(rawRef, 'source');
+  const volume = field(rawRef, 'volume');
+  const fpage = field(rawRef, 'fpage');
+  const title = field(rawRef, 'article-title') || field(rawRef, 'chapter-title') || source;
+
+  // 2. vol+pages SMPTE self-cite — unambiguous keys only
+  if (volume && fpage && isSmpteJournalSource(source)) {
+    const hits = volPages.get(`${volume.trim()}|${fpage.trim()}`);
+    if (hits && hits.length === 1) return { kind: 'canonical', refId: hits[0], via: 'vol+pages' };
+    if (hits && hits.length > 1) return { kind: 'orphan', via: 'vol+pages-ambiguous' };
+  }
+
+  // 3. curated refMap only. parseRefId is DELIBERATELY NOT USED here.
+  //
+  // It reads free text, and these FTXML refs are largely informal citations —
+  // conference talks, vendor briefs, blog posts — whose titles merely MENTION a
+  // standard. Auditing its output on this corpus showed it confidently wrong:
+  //   · `SMPTE.ST2110` absorbed 9 distinct citations, mostly papers ABOUT
+  //     ST 2110 ("Is SMPTE ST 2110 the future of your facility?").
+  //   · `SMPTE.ST259` swallowed a citation to ST 297 — a different standard.
+  //   · `ISO.23090` stood in for parts -3, -5 and -15 simultaneously, since the
+  //     parse drops the part number that distinguishes them.
+  // A volume+fpage "is this an article?" guard can't catch these, because talks
+  // and web citations carry neither.
+  //
+  // Orphan slugs lose nothing by comparison: they keep the raw <ref> XML and the
+  // citation text in the MRI and can graduate to a CORRECT canonical refId later
+  // via resolveOrphans. A wrong canonical link, by contrast, is durable and
+  // invisible. Precision over recall — same rule as never lowercasing a DOI join.
+  if (title) {
+    const mapped = mapRefByCite(title);
+    if (mapped) return { kind: 'canonical', refId: mapped, via: 'mapRefByCite' };
+  }
+
+  // 5. #1229 content-hash pre-check before minting
+  const h = _contentHash(rawRef);
+  if (h && hashToRefId.has(h)) return { kind: 'canonical', refId: hashToRefId.get(h), via: 'content-hash' };
+
+  return { kind: 'orphan', via: 'orphan-slug' };
+}
+
+// ---- walk the catalog ----------------------------------------------------
+const catalog = JSON.parse(fs.readFileSync(CATALOG, 'utf8'));
+const counters = { files: 0, sourceDocs: new Set(), refs: 0, canonical: 0, orphan: 0, inRegistry: 0, knownNoDoc: 0 };
+const byVia = {};
+const perDoc = new Map();   // docId -> ordered refIds/slugs
+const unmapped = [];
+
+for (const f of catalog.files) {
+  if (LIMIT && counters.sourceDocs.size >= LIMIT) break;
+  if (!f.refCount) continue;
+  const doc = docForFtxml(f.path);
+  if (!doc) { unmapped.push(f.path); continue; }
+  counters.files++;
+  counters.sourceDocs.add(doc.docId);
+
+  let xml; try { xml = fs.readFileSync(f.path, 'utf8'); } catch { continue; }
+  const refList = xml.match(/<ref-list\b[\s\S]*?<\/ref-list>/);
+  if (!refList) continue;
+  const rawRefs = refList[0].match(/<ref\b[^>]*>[\s\S]*?<\/ref>/g) || [];
+
+  for (const raw of rawRefs) {
+    counters.refs++;
+    const r = resolve(raw);
+    byVia[r.via] = (byVia[r.via] || 0) + 1;
+
+    if (!perDoc.has(doc.docId)) perDoc.set(doc.docId, []);
+    const bucket = perDoc.get(doc.docId);
+
+    if (r.kind === 'canonical') {
+      counters.canonical++;
+      if (docIds.has(r.refId)) counters.inRegistry++; else counters.knownNoDoc++;
+      if (APPLY) {
+        try {
+          mriRecordSighting({
+            docId: doc.docId, type: 'bibliographic', refId: r.refId,
+            cite: strip(raw.replace(/<ref\b[^>]*>|<\/ref>/g, '')), href: '',
+            rawRef: raw, title: field(raw, 'article-title') || '',
+            mapSource: 'ftxml-extract', mapDetail: r.via,
+          });
+        } catch (e) { console.warn(`[ftxml-refs] mri canonical failed ${doc.docId}/${r.refId}: ${e.message}`); }
+      }
+      if (!bucket.includes(r.refId)) bucket.push(r.refId);
+      continue;
+    }
+
+    counters.orphan++;
+    if (APPLY) {
+      try {
+        const mint = mriRecordSighting({
+          docId: doc.docId, type: 'bibliographic',
+          cite: strip(raw.replace(/<ref\b[^>]*>|<\/ref>/g, '')), href: '',
+          rawRef: raw, title: field(raw, 'article-title') || '',
+          mapSource: 'ftxml-extract', mapDetail: r.via,
+        });
+        const slug = mint && mint.mintedSlug;
+        if (slug && !bucket.includes(slug)) bucket.push(slug);
+      } catch (e) { console.warn(`[ftxml-refs] mint failed ${doc.docId}: ${e.message}`); }
+    } else {
+      // Dry-run: no slug is minted, but the per-doc totals must still reflect
+      // what --apply would write, or the counts appear to jump on apply. The
+      // mint is deterministic — `orphan/<docId>/<ref id>` — so project it.
+      const refXmlId = (raw.match(/<ref\s+id="([^"]+)"/) || [])[1];
+      const projected = `orphan/${doc.docId}/${refXmlId || `h:${String(_contentHash(raw)).slice(0, 8)}`}`;
+      if (!bucket.includes(projected)) bucket.push(projected);
+    }
+  }
+}
+
+// ---- write ---------------------------------------------------------------
+let docsWritten = 0;
+if (APPLY) {
+  for (const [docId, refs] of perDoc) {
+    const doc = byDocId.get(docId);
+    if (!doc || !refs.length) continue;
+    doc.references = doc.references || {};
+    const existing = Array.isArray(doc.references.bibliographic) ? doc.references.bibliographic : [];
+    const merged = [...existing];
+    for (const r of refs) if (!merged.includes(r)) merged.push(r);
+    doc.references.bibliographic = merged;
+    doc.references['bibliographic$meta'] = {
+      source: 'parsed', confidence: 'medium',
+      note: 'Extracted from the FTXML NLM <back><ref-list> via extractFtxmlRefs.js (source doc mapped through its content_batch sibling).',
+      updated: NOW,
+    };
+    saveDoc(doc);
+    docsWritten++;
+  }
+  console.log('[ftxml-refs] flushing MRI…');
+  mriFlush({ force: true });
+}
+
+const summary = {
+  generatedAt: NOW, apply: APPLY, limit: LIMIT || null,
+  totals: {
+    ftxmlFilesWithRefs: counters.files,
+    sourceDocsTouched: counters.sourceDocs.size,
+    refsProcessed: counters.refs,
+    canonical: counters.canonical,
+    canonicalInRegistry: counters.inRegistry,
+    canonicalKnownNoDoc: counters.knownNoDoc,
+    orphanSlugs: counters.orphan,
+    docsWritten,
+    unmappedFiles: unmapped.length,
+  },
+  byVia,
+  perDoc: [...perDoc.entries()].map(([docId, refs]) => ({ docId, refCount: refs.length })),
+};
+fs.writeFileSync(OUT_JSON, JSON.stringify(summary, null, 2) + '\n', 'utf8');
+
+const md = [
+  '# FTXML reference apply — backfill onto the 491 ingested docs\n',
+  `> ${APPLY ? 'APPLY' : 'DRY-RUN'} · ${NOW}${LIMIT ? ` · limit ${LIMIT}` : ''}\n`,
+  '## Totals',
+  `- FTXML files with refs      : ${counters.files}`,
+  `- source docs touched        : **${counters.sourceDocs.size}**`,
+  `- refs processed             : **${counters.refs}**`,
+  `- → canonical refId (direct link) : **${counters.canonical}** (${counters.inRegistry} resolve to a registry doc)`,
+  `- → orphan slug (MRI, EXTERNAL badge) : **${counters.orphan}**`,
+  `- unmapped FTXML files       : ${unmapped.length}`,
+  `- docs written               : ${docsWritten}\n`,
+  '## By resolution path',
+  '| path | refs |',
+  '|---|---:|',
+  ...Object.entries(byVia).sort(([, a], [, b]) => b - a).map(([k, v]) => `| \`${k}\` | ${v} |`),
+  '',
+  '## Notes',
+  '- Source docs are mapped through the **content_batch sibling**, not the FTXML `<article-id>`:',
+  '  conference FTXML carry an empty article DOI, so an FTXML-DOI match strands all 76 of them.',
+  '- `vol+pages` resolves SMPTE self-cites only on **unambiguous** keys; multi-hit keys fall through',
+  '  to an orphan mint rather than guessing.',
+  '- Orphan slugs are not silent: they render as `<cite>` with an EXTERNAL badge, carry the raw XML +',
+  '  citation text in the MRI, and graduate to canonical refIds later via `resolveOrphans` with no',
+  '  doc-file edits.',
+  '- Targets were greenfield (0 of 491 carried references); existing refs are merged, never replaced.\n',
+].join('\n');
+fs.writeFileSync(OUT_MD, md, 'utf8');
+
+console.log(`\n[ftxml-refs] ${APPLY ? 'APPLIED' : 'DRY-RUN'}`);
+console.log(`  source docs touched : ${counters.sourceDocs.size}`);
+console.log(`  refs processed      : ${counters.refs}`);
+console.log(`  canonical links     : ${counters.canonical} (${counters.inRegistry} in registry)`);
+console.log(`  orphan slugs        : ${counters.orphan}`);
+console.log(`  reports             : ${OUT_JSON}, ${OUT_MD}`);
+if (!APPLY) console.log('\n  re-run with --apply to write docs + MRI.');


### PR DESCRIPTION
## Summary

Completes **todo #1** of the canonical-audit handoff. `ftxmlRefWalker.js` (#1241) cataloged 2,995 structured refs in the FTXML NLM full-text XMLs but could not route them — their source articles weren't in the registry. #1241 ingested those 491 docs, so the refs can now be attached.

**Verified before building:** all 289 FTXML files resolve to a real registry doc (**0 unresolved**), all 2,995 refs are attachable, and the targets are **greenfield** — 0 of the 491 docs carried references, so this only adds.

> ⚠️ **Tooling + dry-run only — no data written yet.** The `--apply` is pending and will be a separate `data(audit)` commit.

## Source-doc mapping (the subtle part)

Mapping goes **FTXML → sibling `content_batch` → docId**, *not* via the FTXML's own `<article-id>`. Conference FTXML carry an **empty** article DOI, so an FTXML-DOI match would strand all 76 conference papers.

- **251** map via their `content_batch` DOI
- **38** map via the ISBN/ISSN + `article_sequence` key (the DOI-less ones)

## Resolution chain

1. **direct DOI** — exact case (never lowercase a DOI join)
2. **vol+pages** — SMPTE self-cites, **unambiguous keys only**; multi-hit keys fall through to orphan-mint rather than guess
3. **mapRefByCite** — curated refMap entries
4. **orphan slug** — content-hash pre-checked (#1229) MRI mint

## `parseRefId` deliberately excluded — please review this call

The Phase-3a chain included `parseRefId`, and I initially did too (it contributed the *most* canonical links, 85). Auditing its output on this corpus showed it **confidently wrong**:

- `SMPTE.ST2110` absorbed **9 distinct citations** — mostly papers *about* ST 2110 (*"Is SMPTE ST 2110 the future of your facility?"*, *"SDI vs SMPTE ST 2110"*)
- `SMPTE.ST259` swallowed a citation to **ST 297** — a different standard
- `ISO.23090` stood in for parts **-3, -5 and -15** simultaneously (the parse drops the part number that distinguishes them)

These FTXML refs are largely informal citations — conference talks, vendor briefs, blog posts — whose titles merely *mention* a standard. A volume+fpage "is this an article?" guard can't catch them, because talks and web citations carry neither.

Removing it drops canonical links **123 → 40**, but all 40 now resolve to a real registry doc instead of being MRI-only guesses. Orphan slugs lose nothing: they keep the raw `<ref>` XML and citation text and can graduate to a **correct** refId later via `resolveOrphans` with no doc-file edits. A wrong canonical link is durable and invisible. Precision over recall — the same rule as never lowercasing a DOI join.

Happy to reinstate it with the part-collapse guard only if you'd rather have the recall.

## Dry-run result

| outcome | count |
|---|--:|
| canonical links (all 40 resolve to a registry doc) | **40** |
| orphan slugs (MRI, EXTERNAL badge) | **2,955** |
| source docs receiving refs | **167** |
| refs written after intra-doc dedup | **2,959** |

By path: `direct-doi` 32 · `vol+pages` 6 · `mapRefByCite` 2 · `vol+pages-ambiguous` 2 (→ orphan) · `orphan-slug` 2,953.

Only 40 direct links is expected, not a failure: these are 2024–26 papers citing mostly non-SMPTE work (IETF drafts, JVET documents, arXiv, vendor URLs) absent from the registry. The old Phase-3a pass scored better because the HIGHWIRE corpus was SMPTE-heavy.

## Type of Change
- [x] New feature

## Validation
- [x] Dry-run clean: 289/289 FTXML files mapped, 0 unresolved
- [x] Confirmed targets greenfield (0/491 docs carried references)
- [x] Audited every canonical resolution path for false positives (see above)
- [ ] `--apply` — **pending**, will follow as a separate data commit
- [x] No manual edits in `src/main/reports/` or `src/main/data/` — all generated

## Related
Follows #1241 (FTXML catalog + 491 NLM docs), which unblocked this by creating the source docs.
